### PR TITLE
Add more memory logging to microcircuit

### DIFF
--- a/Potjans_2014/bm_run_microcircuit.py
+++ b/Potjans_2014/bm_run_microcircuit.py
@@ -57,6 +57,8 @@ net_dict.update({
 py_timers = {}
 memory_used = {}
 
+memory_used['base_memory'] = memory()
+
 t0 = time.time()
 net = network.Network(sim_dict, net_dict, stim_dict)
 t1 = time.time()
@@ -65,6 +67,7 @@ py_timers['py_time_network'] = t1 - t0
 net.create()
 t2 = time.time()
 py_timers['py_time_create'] = t2 - t1
+memory_used['node_memory'] = memory()
 
 net.connect()
 t3 = time.time()


### PR DESCRIPTION
During code review I realized there were slight discrepancies of the logging of the memory consumption
The `base_memory`, the memory of the network before any NEST related operations was not recorded in the microcircuit. The `node_memory` which is the memory after the creation of all nodes was only recorded in the `hpc_benchmark`. I added this also to the microcircuit. This is unfortunately not possible for the multi-area model as there node creations and connections are intertwined. First all areas (their nodes plus connections are created) then all areas (cortico-cortical connections) are connected. This PR tries to align the recording of the memory as good as possible.