### PR TITLE
Fix hpc benchmark

### DIFF
--- a/hpc_benchmark/hpc_benchmark.py
+++ b/hpc_benchmark/hpc_benchmark.py
@@ -333,6 +333,19 @@ def build_network():
         nest.Connect(local_neurons[:brunel_params['Nrec']], E_recorder,
                      'all_to_all', 'static_synapse_hpc')
 
+    # ``nest.Connect()`` calls which sets up the postsynaptic connectivity.
+    # Since the introduction of the 5g kernel in NEST 2.16.0 the full
+    # connection infrastructure including presynaptic connectivity is set up
+    # afterwards in the preparation phase of the simulation.
+    # The preparation phase is usually induced by the first
+    # ``nest.Simulate()`` call.
+    # For including this phase in measurements of the connection time,
+    # we induce it here explicitly by calling ``nest.Prepare()``.
+    # Calling directly ``nest.Cleanup()`` afterwards breaks the simulation in
+    # some NEST versions (at least in NEST 2.20.2).
+
+    nest.Prepare()
+
     # read out time used for building
     BuildEdgeTime = time.time() - tic
     network_memory = str(memory_thisjob())
@@ -358,14 +371,32 @@ def run_simulation():
 
     tic = time.time()
 
-    nest.Simulate(params['presimtime'])
+    try:
+        nest.Prepare()
+    except BaseException:
+        print(
+            'nest.Prepare() has already been called after connecting the '
+            'network. '
+            'This simulate() call directly starts with nest.Run().')
 
-    PreparationTime = time.time() - tic
+    nest.Run(params['presimtime'])
+    nest.Cleanup()
+
+    PresimCPUTime = time.time() - tic
     init_memory = str(memory_thisjob())
 
     tic = time.time()
 
-    nest.Simulate(params['simtime'])
+    try:
+        nest.Prepare()
+    except BaseException:
+        print(
+            'nest.Prepare() has already been called after connecting the '
+            'network. '
+            'This simulate() call directly starts with nest.Run().')
+
+    nest.Run(params['simtime'])
+    nest.Cleanup()
 
     SimCPUTime = time.time() - tic
     total_memory = str(memory_thisjob())
@@ -374,7 +405,7 @@ def run_simulation():
     if params['record_spikes']:
         average_rate = compute_rate(sr)
 
-    d = {'py_time_presimulate': PreparationTime,
+    d = {'py_time_presimulate': PresimCPUTime,
          'py_time_simulate': SimCPUTime,
          'base_memory': base_memory,
          'init_memory': init_memory,

--- a/hpc_benchmark/hpc_benchmark_2.py
+++ b/hpc_benchmark/hpc_benchmark_2.py
@@ -448,9 +448,17 @@ def compute_rate(sr):
 
 
 def memory_thisjob():
-    """Wrapper to obtain current memory usage"""
-    nest.ll_api.sr('memory_thisjob')
-    return nest.ll_api.spp()
+    """
+    Use NEST's memory wrapper function to record used memory.
+    """
+    try:
+        mem = nest.ll_api.sli_func('memory_thisjob')
+    except AttributeError:
+        mem = nest.sli_func('memory_thisjob')
+    if isinstance(mem, dict):
+        return mem['heap']
+    else:
+        return mem
 
 
 def lambertwm1(x):

--- a/hpc_benchmark/hpc_benchmark_3.py
+++ b/hpc_benchmark/hpc_benchmark_3.py
@@ -333,6 +333,19 @@ def build_network():
         nest.Connect(local_neurons[:brunel_params['Nrec']], E_recorder,
                      'all_to_all', 'static_synapse_hpc')
 
+    # ``nest.Connect()`` calls which sets up the postsynaptic connectivity.
+    # Since the introduction of the 5g kernel in NEST 2.16.0 the full
+    # connection infrastructure including presynaptic connectivity is set up
+    # afterwards in the preparation phase of the simulation.
+    # The preparation phase is usually induced by the first
+    # ``nest.Simulate()`` call.
+    # For including this phase in measurements of the connection time,
+    # we induce it here explicitly by calling ``nest.Prepare()``.
+    # Calling directly ``nest.Cleanup()`` afterwards breaks the simulation in
+    # some NEST versions (at least in NEST 2.20.2).
+
+    nest.Prepare()
+
     # read out time used for building
     BuildEdgeTime = time.time() - tic
     network_memory = str(memory_thisjob())
@@ -358,14 +371,32 @@ def run_simulation():
 
     tic = time.time()
 
-    nest.Simulate(params['presimtime'])
+    try:
+        nest.Prepare()
+    except BaseException:
+        print(
+            'nest.Prepare() has already been called after connecting the '
+            'network. '
+            'This simulate() call directly starts with nest.Run().')
 
-    PreparationTime = time.time() - tic
+    nest.Run(params['presimtime'])
+    nest.Cleanup()
+
+    PresimCPUTime = time.time() - tic
     init_memory = str(memory_thisjob())
 
     tic = time.time()
 
-    nest.Simulate(params['simtime'])
+    try:
+        nest.Prepare()
+    except BaseException:
+        print(
+            'nest.Prepare() has already been called after connecting the '
+            'network. '
+            'This simulate() call directly starts with nest.Run().')
+
+    nest.Run(params['simtime'])
+    nest.Cleanup()
 
     SimCPUTime = time.time() - tic
     total_memory = str(memory_thisjob())
@@ -374,7 +405,7 @@ def run_simulation():
     if params['record_spikes']:
         average_rate = compute_rate(sr)
 
-    d = {'py_time_presimulate': PreparationTime,
+    d = {'py_time_presimulate': PresimCPUTime,
          'py_time_simulate': SimCPUTime,
          'base_memory': base_memory,
          'init_memory': init_memory,


### PR DESCRIPTION
I realized that the connection phase of the hpc_benchmark lacks the `nest.Prepare()` phase. This should be fixed with this PR.

Furthermore memory retrieval in the hpc_benchmark_2 for nest 2. did not work with all NEST 2 Versions, I tested 2.14, 2.16.0 and 2.20.2 and it only worked with 2.20.2. This should now be fixed.