### PR TITLE
Port delay re-draw fix 

### DIFF
--- a/Potjans_2014/network.py
+++ b/Potjans_2014/network.py
@@ -664,7 +664,10 @@ class Network:
                                     std=(
                                         self.net_dict['delay_matrix_mean'][i][j] *
                                         self.net_dict['delay_rel_std'])),
-                                min=self.sim_resolution,
+                                # resulting minimum delay is equal to resolution, see:
+                                # https://nest-simulator.readthedocs.io/en/latest/nest_behavior
+                                # /random_numbers.html#rounding-effects-when-randomizing-delays
+                                min=nest.resolution - 0.5 * nest.resolution,
                                 max=np.Inf)}
                     elif self.nest_version == '2':
                         syn_dict = {
@@ -774,7 +777,10 @@ class Network:
                             std=(
                                 self.stim_dict['delay_th_mean'] *
                                 self.stim_dict['delay_th_rel_std'])),
-                        min=self.sim_resolution,
+                        # resulting minimum delay is equal to resolution, see:
+                        # https://nest-simulator.readthedocs.io/en/latest/nest_behavior
+                        # /random_numbers.html#rounding-effects-when-randomizing-delays
+                        min=nest.resolution - 0.5 * nest.resolution,
                         max=np.Inf)}
 
             elif self.nest_version == '2':

--- a/Potjans_2014/network_params.py
+++ b/Potjans_2014/network_params.py
@@ -72,10 +72,15 @@ net_dict = {
     # mean rates of the different populations in the non-scaled version of the
     # microcircuit (in spikes/s; same order as in 'populations');
     # necessary for the scaling of the network.
-    # The values were optained by running this PyNEST microcircuit with 12 MPI
-    # processes and both 'N_scaling' and 'K_scaling' set to 1.
+    # The values were obtained by running this PyNEST microcircuit without MPI,
+    # 'local_num_threads' 4 and both 'N_scaling' and 'K_scaling' set to 1.
+    # 
+    # Since these rates were only taken from one simulation, they alone are not sufficient for verification.
+    # For that, rates should be compared to the firing rate plots produced by the network evaluation for individual runs
+    # or the averaged (10 runs) standard deviation per population:
+    # [1.2548324, 2.5248003, 3.43632659, 4.19884825, 5.27534955, 5.51494673, 1.63249623, 5.05082906]
     'full_mean_rates':
-        np.array([0.943, 3.026, 4.368, 5.882, 7.733, 8.664, 1.096, 7.851]),
+        np.array([0.903, 2.965, 4.414, 5.876, 7.569, 8.633, 1.105, 7.829]),
     # connection probabilities (the first index corresponds to the targets
     # and the second to the sources)
     'conn_probs':

--- a/Potjans_2014/network_params.py
+++ b/Potjans_2014/network_params.py
@@ -76,9 +76,7 @@ net_dict = {
     # 'local_num_threads' 4 and both 'N_scaling' and 'K_scaling' set to 1.
     # 
     # Since these rates were only taken from one simulation, they alone are not sufficient for verification.
-    # For that, rates should be compared to the firing rate plots produced by the network evaluation for individual runs
-    # or the averaged (10 runs) standard deviation per population:
-    # [1.2548324, 2.5248003, 3.43632659, 4.19884825, 5.27534955, 5.51494673, 1.63249623, 5.05082906]
+    # For that, rates should be compared to mean values over multiple runs with different RNG seeds.
     'full_mean_rates':
         np.array([0.903, 2.965, 4.414, 5.876, 7.569, 8.633, 1.105, 7.829]),
     # connection probabilities (the first index corresponds to the targets

--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -656,6 +656,7 @@ def connect(simulation,
                 s = network.distances[target_area.name][source_area.name]
                 mean_delay = s / v
 
+            dt = simulation.params['dt']
             syn_spec = {
                 'synapse_model': 'static_synapse',
                 'weight': nest.math.redraw(
@@ -671,7 +672,7 @@ def connect(simulation,
                         mean=mean_delay,
                         std=mean_delay * network.params['delay_params']['delay_rel']
                         ),
-                    min=simulation.params['dt'],
+                    min=dt - 0.5 * dt,
                     max=np.Inf)}
 
             nest.Connect(source_area.gids[source],

--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -656,7 +656,6 @@ def connect(simulation,
                 s = network.distances[target_area.name][source_area.name]
                 mean_delay = s / v
 
-            dt = simulation.params['dt']
             syn_spec = {
                 'synapse_model': 'static_synapse',
                 'weight': nest.math.redraw(
@@ -672,7 +671,7 @@ def connect(simulation,
                         mean=mean_delay,
                         std=mean_delay * network.params['delay_params']['delay_rel']
                         ),
-                    min=dt - 0.5 * dt,
+                    min=simulation.params['dt'] - 0.5 * nest.resolution,
                     max=np.Inf)}
 
             nest.Connect(source_area.gids[source],


### PR DESCRIPTION
- Reference for delay change: https://github.com/nest/nest-simulator/issues/2503
- This was fixed in the NEST-local example a while back but seemingly not updated elsewhere
- Note: This was also applied to MAM now and also needs to be re-re-ported to NEST master