### PR TITLE
Subtract timing information from pre-simulation period

### DIFF
--- a/hpc_benchmark/hpc_benchmark.py
+++ b/hpc_benchmark/hpc_benchmark.py
@@ -415,8 +415,6 @@ def run_simulation():
 
     PreparationTime = time.time() - tic
 
-    time_simulate_presim = nest.kernel_status["time_simulate"]
-
     intermediate_kernel_status = nest.kernel_status
 
     tic = time.time()
@@ -458,20 +456,20 @@ def run_simulation():
          'average_rate': average_rate}
     d.update(build_dict)
     final_kernel_status = nest.kernel_status
-    final_kernel_status["time_simulate"] -= time_simulate_presim
     d.update(final_kernel_status)
 
     # Subtract timer information from presimulation period
     timers = ['time_collocate_spike_data', 'time_communicate_prepare',
               'time_communicate_spike_data', 'time_communicate_target_data',
               'time_deliver_spike_data', 'time_gather_spike_data',
-              'time_gather_target_data', 'time_update']
+              'time_gather_target_data', 'time_update', 'time_simulate']
 
     for timer in timers:
         try:
+            d[timer + '_presim'] = intermediate_kernel_status[timer]
             d[timer] -= intermediate_kernel_status[timer]
         except KeyError:
-            # KeyError if compiled without detailed timers
+            # KeyError if compiled without detailed timers, except time_simulate
             continue
     print(d)
 

--- a/hpc_benchmark/hpc_benchmark.py
+++ b/hpc_benchmark/hpc_benchmark.py
@@ -417,6 +417,8 @@ def run_simulation():
 
     time_simulate_presim = nest.kernel_status["time_simulate"]
 
+    intermediate_kernel_status = nest.kernel_status
+
     tic = time.time()
 
     for d in range(sim_steps):
@@ -458,6 +460,19 @@ def run_simulation():
     final_kernel_status = nest.kernel_status
     final_kernel_status["time_simulate"] -= time_simulate_presim
     d.update(final_kernel_status)
+
+    # Subtract timer information from presimulation period
+    timers = ['time_collocate_spike_data', 'time_communicate_prepare',
+              'time_communicate_spike_data', 'time_communicate_target_data',
+              'time_deliver_spike_data', 'time_gather_spike_data',
+              'time_gather_target_data', 'time_update']
+
+    for timer in timers:
+        try:
+            d[timer] -= intermediate_kernel_status[timer]
+        except KeyError:
+            # KeyError if compiled without detailed timers
+            continue
     print(d)
 
     nest.Cleanup()


### PR DESCRIPTION
I think I noticed a bug with the timers in the HPC Benchmark model.
When noticed that when plotting the simulation time together with the timers that the sum of all timers is above the simulation time.
I think the reason for this is that we don't subtract the timing information for the pre-simulation period before the final readout.
Here I suggest a change fixing this.