### PR TITLE
Seperate profiling runs from performance runs

### DIFF
--- a/hpc_benchmark/hpc_benchmark.py
+++ b/hpc_benchmark/hpc_benchmark.py
@@ -443,10 +443,11 @@ def run_simulation():
         build_dict, sr = build_network()
 
         tic = time.time()
-
+        base_memory = str(get_vmsize())
         nest.Prepare()
 
         InitTime = time.time() - tic
+        init_memory = str(get_vmsize())
 
         tic = time.time()
         nest.Run(params['presimtime'])
@@ -457,6 +458,7 @@ def run_simulation():
         tic = time.time()
         nest.Run(params['presimtime'])
         SimCPUTime = time.time() - tic
+        total_memory = str(get_vmsize())
 
     average_rate = 0.0
     if params['record_spikes']:
@@ -465,13 +467,13 @@ def run_simulation():
     d = {'py_time_init': InitTime,
          'py_time_presimulate': PreparationTime,
          'py_time_simulate': SimCPUTime,
-         'average_rate': average_rate}
+         'average_rate': average_rate,
+         'base_memory': base_memory,
+         'init_memory': init_memory,
+         'total_memory': total_memory}
 
     if params['profile_memory']:
-        memory_dict = {'base_memory': base_memory,
-                       'init_memory': init_memory,
-                       'total_memory': total_memory,
-                       'base_memory_rss': base_memory_rss,
+        memory_dict = {'base_memory_rss': base_memory_rss,
                        'init_memory_rss': init_memory_rss,
                        'total_memory_rss': total_memory_rss,
                        'base_memory_peak': base_memory_peak,

--- a/hpc_benchmark/hpc_benchmark.py
+++ b/hpc_benchmark/hpc_benchmark.py
@@ -486,9 +486,8 @@ def run_simulation():
 
     # Subtract timer information from presimulation period
     timers = ['time_collocate_spike_data', 'time_communicate_prepare',
-              'time_communicate_spike_data', 'time_communicate_target_data',
-              'time_deliver_spike_data', 'time_gather_spike_data',
-              'time_gather_target_data', 'time_update', 'time_simulate']
+              'time_communicate_spike_data', 'time_deliver_spike_data',
+              'time_gather_spike_data', 'time_update', 'time_simulate']
 
     for timer in timers:
         try:


### PR DESCRIPTION
This is a fix to separate benchmarking from profiling runs.
The ```run``` call is not split, in either pre-sim or sim periods.