### PR TITLE
MAM new timers

### DIFF
--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -288,7 +288,7 @@ class Simulation:
         Create the network and execute simulation.
         Record used memory and wallclock time.
         """
-        tic = time.time()
+        t0 = time.time()
         self.base_memory = self.memory()
         self.prepare()
         t1 = time.time()

--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -325,7 +325,7 @@ class Simulation:
         self.init_memory = self.memory()
         print("Presimulation time in {0:.2f} seconds.".format(self.time_presimulate))
 
-        intermediate_kernel_status = nest.kernel_status
+        self.intermediate_kernel_status = nest.kernel_status
 
         t6 = time.time()
         nest.Run(self.T)
@@ -377,20 +377,20 @@ class Simulation:
         for timer in presim_timers:
             try:
                 if type(d[timer]) == tuple or type(d[timer]) == list:
-                    timer_array = tuple(d[timer][tid] - intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
+                    timer_array = tuple(d[timer][tid] - self.intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
                     d[timer] = timer_array[0]
                     d[timer + "_max"] = max(timer_array)
                     d[timer + "_min"] = min(timer_array)
                     d[timer + "_mean"] = np.mean(timer_array)
                     d[timer + "_all"] = timer_array
-                    d[timer + '_presim'] = intermediate_kernel_status[timer][0]
-                    d[timer + "_presim_max"] = max(intermediate_kernel_status[timer])
-                    d[timer + "_presim_min"] = min(intermediate_kernel_status[timer])
-                    d[timer + "_presim_avg"] = np.mean(intermediate_kernel_status[timer])
-                    d[timer + "_presim_all"] = intermediate_kernel_status[timer]
+                    d[timer + '_presim'] = self.intermediate_kernel_status[timer][0]
+                    d[timer + "_presim_max"] = max(self.intermediate_kernel_status[timer])
+                    d[timer + "_presim_min"] = min(self.intermediate_kernel_status[timer])
+                    d[timer + "_presim_avg"] = np.mean(self.intermediate_kernel_status[timer])
+                    d[timer + "_presim_all"] = self.intermediate_kernel_status[timer]
                 else:
-                    d[timer] -= intermediate_kernel_status[timer]
-                    d[timer + '_presim'] = intermediate_kernel_status[timer]
+                    d[timer] -= self.intermediate_kernel_status[timer]
+                    d[timer + '_presim'] = self.intermediate_kernel_status[timer]
             except KeyError:
                 # KeyError if compiled without detailed timers, except time_simulate
                 continue

--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -377,13 +377,11 @@ class Simulation:
         for timer in presim_timers:
             try:
                 if type(d[timer]) == tuple or type(d[timer]) == list:
-                    print(f'tuple timer {timer}: ', d[timer])
                     timer_array = tuple(d[timer][tid] - self.intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
                     d[timer] = timer_array[0]
                     d[timer + "_max"] = max(timer_array)
                     d[timer + "_min"] = min(timer_array)
                     d[timer + "_mean"] = np.mean(timer_array)
-                    print(f'tuple timer {timer} mean: ', d[timer+'_mean'])
                     d[timer + "_all"] = timer_array
                     d[timer + '_presim'] = self.intermediate_kernel_status[timer][0]
                     d[timer + "_presim_max"] = max(self.intermediate_kernel_status[timer])
@@ -391,7 +389,6 @@ class Simulation:
                     d[timer + "_presim_avg"] = np.mean(self.intermediate_kernel_status[timer])
                     d[timer + "_presim_all"] = self.intermediate_kernel_status[timer]
                 else:
-                    print(f'timer {timer}: ', d[timer])
                     d[timer] -= self.intermediate_kernel_status[timer]
                     d[timer + '_presim'] = self.intermediate_kernel_status[timer]
             except KeyError:

--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -377,11 +377,13 @@ class Simulation:
         for timer in presim_timers:
             try:
                 if type(d[timer]) == tuple or type(d[timer]) == list:
+                    print(f'tuple timer {timer}: ', d[timer])
                     timer_array = tuple(d[timer][tid] - self.intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
                     d[timer] = timer_array[0]
                     d[timer + "_max"] = max(timer_array)
                     d[timer + "_min"] = min(timer_array)
                     d[timer + "_mean"] = np.mean(timer_array)
+                    print(f'tuple timer {timer} mean: ', d[timer+'_mean'])
                     d[timer + "_all"] = timer_array
                     d[timer + '_presim'] = self.intermediate_kernel_status[timer][0]
                     d[timer + "_presim_max"] = max(self.intermediate_kernel_status[timer])
@@ -389,6 +391,7 @@ class Simulation:
                     d[timer + "_presim_avg"] = np.mean(self.intermediate_kernel_status[timer])
                     d[timer + "_presim_all"] = self.intermediate_kernel_status[timer]
                 else:
+                    print(f'timer {timer}: ', d[timer])
                     d[timer] -= self.intermediate_kernel_status[timer]
                     d[timer + '_presim'] = self.intermediate_kernel_status[timer]
             except KeyError:


### PR DESCRIPTION
This PR changes the logging of the timers in the MAM code to be compatible with the threaded timers introduced in NEST 3.9. 