### PR TITLE
Fix logging for version PyNEST_NG

### DIFF
--- a/Potjans_2014/bm_helpers.py
+++ b/Potjans_2014/bm_helpers.py
@@ -21,7 +21,7 @@ def logging(py_timers=None, memory_used=None, intermediate_kernel_status={}):
     
     for timer in presim_timers:
         try:
-            if type(d[timer]) == tuple or type(d[timer]) == list:
+            if isinstance(d[timer], (tuple, list, np.ndarray)):   
                 timer_array = tuple(d[timer][tid] - intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
                 d[timer] = timer_array[0]
                 d[timer + "_max"] = max(timer_array)
@@ -42,7 +42,7 @@ def logging(py_timers=None, memory_used=None, intermediate_kernel_status={}):
                
     for timer in other_timers:
         try:
-            if type(d[timer]) == tuple or type(d[timer]) == list:
+            if isinstance(d[timer], (tuple, list, np.ndarray)): 
                 timer_array = d[timer]
                 d[timer] = timer_array[0]
                 d[timer + "_max"] = max(timer_array)

--- a/Potjans_2014/bm_helpers.py
+++ b/Potjans_2014/bm_helpers.py
@@ -21,7 +21,7 @@ def logging(py_timers=None, memory_used=None, intermediate_kernel_status={}):
     
     for timer in presim_timers:
         try:
-            if isinstance(d[timer], (tuple, list, np.ndarray)):   
+            try:   
                 timer_array = tuple(d[timer][tid] - intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
                 d[timer] = timer_array[0]
                 d[timer + "_max"] = max(timer_array)
@@ -33,7 +33,8 @@ def logging(py_timers=None, memory_used=None, intermediate_kernel_status={}):
                 d[timer + "_presim_min"] = min(intermediate_kernel_status[timer])
                 d[timer + "_presim_avg"] = np.mean(intermediate_kernel_status[timer])
                 d[timer + "_presim_all"] = intermediate_kernel_status[timer]
-            else:
+            except TypeError:
+                # No threaded timers, fall back to scalar handling
                 d[timer] -= intermediate_kernel_status[timer]
                 d[timer + '_presim'] = intermediate_kernel_status[timer]
         except KeyError:
@@ -42,13 +43,16 @@ def logging(py_timers=None, memory_used=None, intermediate_kernel_status={}):
                
     for timer in other_timers:
         try:
-            if isinstance(d[timer], (tuple, list, np.ndarray)): 
+            try: 
                 timer_array = d[timer]
                 d[timer] = timer_array[0]
                 d[timer + "_max"] = max(timer_array)
                 d[timer + "_min"] = min(timer_array)
                 d[timer + "_mean"] = np.mean(timer_array)
                 d[timer + "_all"] = timer_array
+            except TypeError:
+                # No threaded timers, d[timer] is already a scalar and is set after nest.kernel_status
+                continue
         except KeyError:
             # KeyError if compiled without detailed timers, except time_simulate
             continue

--- a/hpc_benchmark/hpc_benchmark.py
+++ b/hpc_benchmark/hpc_benchmark.py
@@ -497,7 +497,7 @@ def run_simulation():
 
     for timer in presim_timers:
         try:
-            if isinstance(d[timer], (tuple, list, np.ndarray)): 
+            try:
                 timer_array = tuple(d[timer][tid] - intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
                 d[timer] = timer_array[0]
                 d[timer + "_max"] = max(timer_array)
@@ -509,7 +509,8 @@ def run_simulation():
                 d[timer + "_presim_min"] = min(intermediate_kernel_status[timer])
                 d[timer + "_presim_avg"] = np.mean(intermediate_kernel_status[timer])
                 d[timer + "_presim_all"] = intermediate_kernel_status[timer]
-            else:
+            except TypeError:
+                # No threaded timers, fall back to scalar handling
                 d[timer] -= intermediate_kernel_status[timer]
                 d[timer + '_presim'] = intermediate_kernel_status[timer]
         except KeyError:
@@ -518,13 +519,16 @@ def run_simulation():
                
     for timer in other_timers:
         try:
-            if isinstance(d[timer], (tuple, list, np.ndarray)): 
+            try: 
                 timer_array = d[timer]
                 d[timer] = timer_array[0]
                 d[timer + "_max"] = max(timer_array)
                 d[timer + "_min"] = min(timer_array)
                 d[timer + "_mean"] = np.mean(timer_array)
                 d[timer + "_all"] = timer_array
+            except TypeError:
+                # No threaded timers, d[timer] is already a scalar and is set after nest.kernel_status
+                continue
         except KeyError:
             # KeyError if compiled without detailed timers, except time_simulate
             continue

--- a/hpc_benchmark/hpc_benchmark.py
+++ b/hpc_benchmark/hpc_benchmark.py
@@ -497,7 +497,7 @@ def run_simulation():
 
     for timer in presim_timers:
         try:
-            if type(d[timer]) == tuple or type(d[timer]) == list:
+            if isinstance(d[timer], (tuple, list, np.ndarray)): 
                 timer_array = tuple(d[timer][tid] - intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
                 d[timer] = timer_array[0]
                 d[timer + "_max"] = max(timer_array)
@@ -518,7 +518,7 @@ def run_simulation():
                
     for timer in other_timers:
         try:
-            if type(d[timer]) == tuple or type(d[timer]) == list:
+            if isinstance(d[timer], (tuple, list, np.ndarray)): 
                 timer_array = d[timer]
                 d[timer] = timer_array[0]
                 d[timer + "_max"] = max(timer_array)

--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -376,7 +376,7 @@ class Simulation:
 
         for timer in presim_timers:
             try:
-                if type(d[timer]) == tuple or type(d[timer]) == list:
+                if isinstance(d[timer], (tuple, list, np.ndarray)):   
                     timer_array = tuple(d[timer][tid] - self.intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
                     d[timer] = timer_array[0]
                     d[timer + "_max"] = max(timer_array)
@@ -397,7 +397,7 @@ class Simulation:
 
         for timer in other_timers:
             try:
-                if type(d[timer]) == tuple or type(d[timer]) == list:
+                if isinstance(d[timer], (tuple, list, np.ndarray)): 
                     timer_array = d[timer]
                     d[timer] = timer_array[0]
                     d[timer + "_max"] = max(timer_array)

--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -376,7 +376,7 @@ class Simulation:
 
         for timer in presim_timers:
             try:
-                if isinstance(d[timer], (tuple, list, np.ndarray)):   
+                try:   
                     timer_array = tuple(d[timer][tid] - self.intermediate_kernel_status[timer][tid] for tid in range(len(d[timer])))
                     d[timer] = timer_array[0]
                     d[timer + "_max"] = max(timer_array)
@@ -388,7 +388,8 @@ class Simulation:
                     d[timer + "_presim_min"] = min(self.intermediate_kernel_status[timer])
                     d[timer + "_presim_avg"] = np.mean(self.intermediate_kernel_status[timer])
                     d[timer + "_presim_all"] = self.intermediate_kernel_status[timer]
-                else:
+                except TypeError:
+                    # No threaded timers, fall back to scalar handling
                     d[timer] -= self.intermediate_kernel_status[timer]
                     d[timer + '_presim'] = self.intermediate_kernel_status[timer]
             except KeyError:
@@ -397,13 +398,16 @@ class Simulation:
 
         for timer in other_timers:
             try:
-                if isinstance(d[timer], (tuple, list, np.ndarray)): 
+                try:
                     timer_array = d[timer]
                     d[timer] = timer_array[0]
                     d[timer + "_max"] = max(timer_array)
                     d[timer + "_min"] = min(timer_array)
                     d[timer + "_mean"] = np.mean(timer_array)
                     d[timer + "_all"] = timer_array
+                except TypeError:
+                    # No threaded timers, d[timer] is already a scalar and is set after nest.kernel_status
+                    continue
             except KeyError:
                 # KeyError if compiled without detailed timers, except time_simulate
                 continue


### PR DESCRIPTION
When threaded timers are enabled, PyNEST_NG returns a NumPy array instead of a tuple like the previous versions. The logging functions in the models assume the value is a tuple or a list, so they do not preprocess it as intended in the case of PyNEST_NG.