### PR TITLE
Make MAM compatible with older NEST versions again

### DIFF
--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -160,10 +160,13 @@ class Simulation:
                               'overwrite_files': True,
                               'data_path': os.path.join(self.data_dir, 'recordings'),
                               'print_time': False,
-                              'rng_seed': rng_seed,
-                              'spike_buffer_grow_extra': self.params['spike_buffer_grow_extra'],
-                              'spike_buffer_shrink_limit': self.params['spike_buffer_shrink_limit'],
-                              'spike_buffer_shrink_spare': self.params['spike_buffer_shrink_spare']})
+                              'rng_seed': rng_seed})
+        try:
+            nest.SetKernelStatus({'spike_buffer_grow_extra': self.params['spike_buffer_grow_extra'],
+                                  'spike_buffer_shrink_limit': self.params['spike_buffer_shrink_limit'],
+                                  'spike_buffer_shrink_spare': self.params['spike_buffer_shrink_spare']})
+        except:
+            print("Unable to set spike_buffer_grow_extra, spike_buffer_shrink_limit, and spike_buffer_shrink_spare.")
 
         # nest.set_verbosity('M_INFO')
 


### PR DESCRIPTION
This is a fix by @JanVogelsang created for cross-version comparison of benchmark runs with older versions of NEST.