### PR TITLE
Check whether number_of_synapses > 0 before calling `nest.Connect()`

### DIFF
--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -665,44 +665,49 @@ def connect(simulation,
                              source_area.name)
     for target in target_area.populations:
         for source in source_area.populations:
-            conn_spec = {'rule': 'fixed_total_number',
-                         'N': int(synapses[target][source])}
 
-            if target_area == source_area:
-                if 'E' in source:
+            # Number of synapses
+            number_of_synapses = math.ceil(synapses[target][source])
+
+            if number_of_synapses > 0:
+                conn_spec = {'rule': 'fixed_total_number',
+                             'N': int(synapses[target][source])}
+
+                if target_area == source_area:
+                    if 'E' in source:
+                        w_min = 0.
+                        w_max = np.inf
+                        mean_delay = network.params['delay_params']['delay_e']
+                    elif 'I' in source:
+                        w_min = -np.inf
+                        w_max = 0.
+                        mean_delay = network.params['delay_params']['delay_i']
+                else:
                     w_min = 0.
                     w_max = np.inf
-                    mean_delay = network.params['delay_params']['delay_e']
-                elif 'I' in source:
-                    w_min = -np.inf
-                    w_max = 0.
-                    mean_delay = network.params['delay_params']['delay_i']
-            else:
-                w_min = 0.
-                w_max = np.inf
-                v = network.params['delay_params']['interarea_speed']
-                s = network.distances[target_area.name][source_area.name]
-                mean_delay = s / v
+                    v = network.params['delay_params']['interarea_speed']
+                    s = network.distances[target_area.name][source_area.name]
+                    mean_delay = s / v
 
-            syn_spec = {
-                'synapse_model': 'static_synapse',
-                'weight': nest.math.redraw(
-                    nest.random.normal(
-                        mean=W[target][source],
-                        std=W_sd[target][source]
+                syn_spec = {
+                    'synapse_model': 'static_synapse',
+                    'weight': nest.math.redraw(
+                        nest.random.normal(
+                            mean=W[target][source],
+                            std=W_sd[target][source]
+                            ),
+                        min=w_min,
+                        max=w_max
                         ),
-                    min=w_min,
-                    max=w_max
-                    ),
-                'delay': nest.math.redraw(
-                    nest.random.normal(
-                        mean=mean_delay,
-                        std=mean_delay * network.params['delay_params']['delay_rel']
-                        ),
-                    min=simulation.params['dt'] - 0.5 * nest.resolution,
-                    max=np.Inf)}
+                    'delay': nest.math.redraw(
+                        nest.random.normal(
+                            mean=mean_delay,
+                            std=mean_delay * network.params['delay_params']['delay_rel']
+                            ),
+                        min=simulation.params['dt'] - 0.5 * nest.resolution,
+                        max=np.Inf)}
 
-            nest.Connect(source_area.gids[source],
-                         target_area.gids[target],
-                         conn_spec,
-                         syn_spec)
+                nest.Connect(source_area.gids[source],
+                             target_area.gids[target],
+                             conn_spec,
+                             syn_spec)

--- a/multi-area-model/multiarea_model/simulation_3.py
+++ b/multi-area-model/multiarea_model/simulation_3.py
@@ -22,6 +22,7 @@ import os
 import pprint
 import shutil
 import time
+import math
 
 from .analysis_helpers import _load_npy_to_dict, model_iter
 from config import base_path


### PR DESCRIPTION
The function `connect()` in `simulation_3.py` loops over all source and target populations and connects them with `nest.Connect()`. This PR adds a line `if number_of_synapses > 0`, so that `nest.Connect()` is only called if the source and target population are actually connected. Because many pairs of populations are not connected, this should save some time for the network construction.